### PR TITLE
update ticker documentation to include new params

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ This API can currently retrieve the following data from [coinmarketcap.com](http
 - **`Optional parameters:`**
     - **(int) start** - return results from rank [start] and above (default is 1)
     - **(int) limit** - return a maximum of [limit] results (default is 100; max is 100)
+    - **(string) sort** - return results sorted by [sort]. Possible values are: "id", "rank", "volume_24h", and "percent_change_24h" (default is rank)
+      - *Note: It is strongly recommended to use id to sort if paginating through all available results since id is the only sort option guaranteed to return in a consistent order.*
+    - **(string) structure** - specify the structure for the main data field. Possible values are dictionary and array (default is dictionary).
     - **(string) convert** - return pricing info in terms of another currency.
     Valid fiat currency values are: "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR"
     Valid cryptocurrency values are: "BTC", "ETH" "XRP", "LTC", and "BCH"
-    - **(string) sort** - return results sorted by [sort]. Possible values are: "id", "rank", "volume_24h", and "percent_change_24h" (default is rank)
+
 ```python
 >>> from coinmarketcap import Market
 >>> coinmarketcap = Market()
@@ -178,6 +181,7 @@ This API can currently retrieve the following data from [coinmarketcap.com](http
 #### **`GET /v2/ticker/{id}`**
 - **`Description`** - This endpoint displays ticker data for a specific cryptocurrency. Use the ```id``` field from the ```listings``` endpoint in the URL.
 - **`Optional parameters:`**
+    - **(string) structure**  - specify the structure for the main data field. Possible values are dictionary and array (default is dictionary).
     - **(string) convert** - return pricing info in terms of another currency.
     Valid fiat currency values are: “AUD”, “BRL”, “CAD”, “CHF”, “CLP”, “CNY”, “CZK”, “DKK”, “EUR”, “GBP”, “HKD”, “HUF”, “IDR”, “ILS”, “INR”, “JPY”, “KRW”, “MXN”, “MYR”, “NOK”, “NZD”, “PHP”, “PKR”, “PLN”, “RUB”, “SEK”, “SGD”, “THB”, “TRY”, “TWD”, “ZAR”
     Valid cryptocurrency values are: “BTC”, “ETH” “XRP”, “LTC”, and “BCH”

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # ![icon](https://raw.githubusercontent.com/barnumbirr/coinmarketcap/master/doc/coinmarketcap.png) coinmarketcap
 
 [![PyPi Version](http://img.shields.io/pypi/v/coinmarketcap.svg)](https://pypi.python.org/pypi/coinmarketcap/)
@@ -70,11 +71,11 @@ This API can currently retrieve the following data from [coinmarketcap.com](http
     - **(string) convert** - return pricing info in terms of another currency.
     Valid fiat currency values are: "AUD", "BRL", "CAD", "CHF", "CLP", "CNY", "CZK", "DKK", "EUR", "GBP", "HKD", "HUF", "IDR", "ILS", "INR", "JPY", "KRW", "MXN", "MYR", "NOK", "NZD", "PHP", "PKR", "PLN", "RUB", "SEK", "SGD", "THB", "TRY", "TWD", "ZAR"
     Valid cryptocurrency values are: "BTC", "ETH" "XRP", "LTC", and "BCH"
-
+    - **(string) sort** - return results sorted by [sort]. Possible values are: "id", "rank", "volume_24h", and "percent_change_24h" (default is rank)
 ```python
 >>> from coinmarketcap import Market
 >>> coinmarketcap = Market()
->>> coinmarketcap.ticker(start=0, limit=3, convert='EUR')
+>>> coinmarketcap.ticker(start=0, limit=3, convert='EUR', sort='rank')
 {
     "cached": false,
     "data": {


### PR DESCRIPTION
In the CoinMarketCap documentation for API v2, it "sort" is a parameter that can be included in the query for tickers. I tried it out with the current version of the library and it worked, so I updated the documentation to reflect this.

Also, the current sample return from the ticker call looks like it was sorted via rank and not the default. I updated the example call to reflect this.